### PR TITLE
Fixes #10

### DIFF
--- a/src/main/java/org/apache/kafka/connect/redis/RedisSourceTask.java
+++ b/src/main/java/org/apache/kafka/connect/redis/RedisSourceTask.java
@@ -17,7 +17,6 @@ package org.apache.kafka.connect.redis;
  * limitations under the License.
  */
 
-import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -98,7 +97,7 @@ public class RedisSourceTask extends SourceTask {
         final Map<String, ?> offset = Collections.singletonMap(RedisSourceConfig.OFFSET_KEY, timestamp);
         try {
             final String cmd = mapper.writeValueAsString(event);
-            record = new SourceRecord(partition, offset, this.topic, null, bytesSchema, ByteBuffer.wrap(event.getClass().getName().getBytes()), null, cmd, timestamp);
+            record = new SourceRecord(partition, offset, this.topic, null, bytesSchema, event.getClass().getName().getBytes(), null, cmd, timestamp);
         } catch (final JsonProcessingException e) {
             log.error("Error converting event to JSON", e);
         }

--- a/src/test/java/org/apache/kafka/connect/redis/RedisSourceTaskTest.java
+++ b/src/test/java/org/apache/kafka/connect/redis/RedisSourceTaskTest.java
@@ -5,7 +5,6 @@ import static java.lang.Thread.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -59,7 +58,7 @@ public class RedisSourceTaskTest {
 
         assertThat(sourceRecord, is(notNullValue()));
         assertThat(sourceRecord.key(), is(notNullValue()));
-        assertThat(new String(((ByteBuffer) sourceRecord.key()).array()), is(LPushCommand.class.getName()));
+        assertThat(new String((byte[])sourceRecord.key()), is(LPushCommand.class.getName()));
         assertThat(sourceRecord.value(), is(notNullValue()));
         assertThat(sourceRecord.value().toString(), is("{\"key\":\"a2V5\",\"values\":[\"dmFsdWUx\",\"dmFsdWUy\"]}"));
 


### PR DESCRIPTION
- In SourceRecord the bytes array was wrapped using ByteBuffer.wrap which causes the issue.

- Fixes the code to send across the byte[] directly w/o any wrapping.

- Updates unit tests